### PR TITLE
Fix listener fails when array value in state is undefined

### DIFF
--- a/polymer-redux.js
+++ b/polymer-redux.js
@@ -26,7 +26,7 @@
                     }
 
                     // type of array, work out splices before setting the value
-                    if (property.type === Array) {
+                    if (property.type === Array && value !== undefined) {
                         // compare the splices from a previous copy
                         previous = prevArrays[property.name] || [];
                         splices = Polymer.ArraySplice.calculateSplices(value, previous);


### PR DESCRIPTION
I found an issue in the calculation of splices; namely when a statePath points to redux state which is not (yet) defined, calling:

`Polymer.ArraySplice.calculateSplices(undefined, previous);`

will throw.