### PR TITLE
Allowstateprop

### DIFF
--- a/polymer-redux.js
+++ b/polymer-redux.js
@@ -19,11 +19,13 @@
                     var splices = [];
                     var value, previous;
 
-                    // statePath a path or function
-                    if (typeof property.path == 'function') {
-                        value = property.path.call(element, state);
+                    // statePath, a path or function.
+                    var path = property.path;
+                    if (typeof path == 'function') {
+                        value = path.call(element, state);
                     } else {
-                        value = Polymer.Base.get(property.path, state);
+
+                        value = Polymer.Base.get(path, state);
                     }
 
                     // type of array, work out splices before setting the value
@@ -77,7 +79,8 @@
                         }
                         props.push({
                             name: name,
-                            path: prop.statePath,
+                            // Empty statePath return state
+                            path: prop.statePath || store.getState,
                             readOnly: prop.readOnly,
                             type: prop.type
                         });

--- a/polymer-redux.js
+++ b/polymer-redux.js
@@ -69,8 +69,8 @@
 
                 // property bindings
                 Object.keys(element.properties).forEach(function(name) {
-                    if (element.properties[name].statePath) {
-                        prop = element.properties[name];
+                    prop = element.properties[name];
+                    if (prop.hasOwnProperty("statePath")) {
                         // notify flag, warn against two-way bindings
                         if (prop.notify && !prop.readOnly) {
                             console.warn(warning, tag, name);

--- a/polymer-redux.js
+++ b/polymer-redux.js
@@ -24,7 +24,6 @@
                     if (typeof path == 'function') {
                         value = path.call(element, state);
                     } else {
-
                         value = Polymer.Base.get(path, state);
                     }
 
@@ -72,7 +71,7 @@
                 // property bindings
                 Object.keys(element.properties).forEach(function(name) {
                     prop = element.properties[name];
-                    if (prop.hasOwnProperty("statePath")) {
+                    if (prop.hasOwnProperty('statePath')) {
                         // notify flag, warn against two-way bindings
                         if (prop.notify && !prop.readOnly) {
                             console.warn(warning, tag, name);


### PR DESCRIPTION
Allow empty string in statePath to subscribe to the state object, because it may not obvious that it doesn't work.

```javascript    
  Polymer({
      is: 'my-element',
      behaviors: [ ReduxBehavior ],
        properties: {
          myState: {
              type: String,
              statePath: ''
          }
      }
  });
```

Before you needed to do this:
```javascript
 Polymer({
      is: 'my-element',
      behaviors: [ ReduxBehavior ],
        properties: {
          myState: {
              type: String,
              statePath: function(){
                          return this.getState();
                 }
            }
      }
  });
```