### PR TITLE
Prevent bower install when installing through npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Polymer bindings for Redux.",
   "main": "polymer-redux.js",
   "scripts": {
-    "postinstall": "bower install",
     "test": "gulp test",
     "lint": "polylint"
   },


### PR DESCRIPTION
When installing polymer-redux as npm dependency, the postinstall hooks kicks in and will trigger a bower install the project. This isn't necessary.