### PR TITLE
Support for Webpack module loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "Polymer bindings for Redux.",
   "main": "lib/polymer-redux.js",
+  "module": "src/index.js",
   "jsnext:main": "src/index.js",
   "scripts": {
     "build": "gulp",

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ export default function PolymerRedux(store) {
 	const collect = (what, which) => {
 		let res = {};
 		while (what) {
-			res = {...what[which], ...res}; // Respect prototype priority
+			res = Object.assign({}, what[which], res); // Respect prototype priority
 			what = Object.getPrototypeOf(what);
 		}
 		return res;


### PR DESCRIPTION
Resolves #93 by adding an entry point for the Webpack module loader.

You can now write `import polymerRedux from 'polymer-redux';` to import the bindings.

Needed to drop the spread operator, otherwise `babel-loader` wouldn't compile the bundle.