### PR TITLE
Fix multiple properties observers are called several times.

### DIFF
--- a/dist/polymer-redux.html
+++ b/dist/polymer-redux.html
@@ -82,18 +82,13 @@ function PolymerRedux(store) {
 		var update = function update(state) {
 			var propertiesChanged = false;
 			bindings.forEach(function (name) {
-				var _properties$name = properties[name],
-				    statePath = _properties$name.statePath,
-				    readOnly = _properties$name.readOnly;
+				// Perhaps .reduce() to a boolean?
+				var statePath = properties[name].statePath;
 
 				var value = typeof statePath === 'function' ? statePath.call(element, state) : Polymer.Path.get(state, statePath);
 
-				if (readOnly) {
-					element._setProperty(name, value);
-				} else {
-					element._setPendingPropertyOrPath(name, value);
-					propertiesChanged = true;
-				}
+				var changed = element._setPendingPropertyOrPath(name, value, true);
+				propertiesChanged = propertiesChanged || changed;
 			});
 			if (propertiesChanged) {
 				element._invalidateProperties();

--- a/dist/polymer-redux.html
+++ b/dist/polymer-redux.html
@@ -80,6 +80,7 @@ function PolymerRedux(store) {
    * @param {Object} state
    */
 		var update = function update(state) {
+			var propertiesChanged = false;
 			bindings.forEach(function (name) {
 				var _properties$name = properties[name],
 				    statePath = _properties$name.statePath,
@@ -90,9 +91,13 @@ function PolymerRedux(store) {
 				if (readOnly) {
 					element._setProperty(name, value);
 				} else {
-					element[name] = value;
+					element._setPendingPropertyOrPath(name, value);
+					propertiesChanged = true;
 				}
 			});
+			if (propertiesChanged) {
+				element._invalidateProperties();
+			}
 		};
 
 		// Redux listener

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,18 +82,13 @@ function PolymerRedux(store) {
 		var update = function update(state) {
 			var propertiesChanged = false;
 			bindings.forEach(function (name) {
-				var _properties$name = properties[name],
-				    statePath = _properties$name.statePath,
-				    readOnly = _properties$name.readOnly;
+				// Perhaps .reduce() to a boolean?
+				var statePath = properties[name].statePath;
 
 				var value = typeof statePath === 'function' ? statePath.call(element, state) : Polymer.Path.get(state, statePath);
 
-				if (readOnly) {
-					element._setProperty(name, value);
-				} else {
-					element._setPendingPropertyOrPath(name, value);
-					propertiesChanged = true;
-				}
+				var changed = element._setPendingPropertyOrPath(name, value, true);
+				propertiesChanged = propertiesChanged || changed;
 			});
 			if (propertiesChanged) {
 				element._invalidateProperties();

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,6 +80,7 @@ function PolymerRedux(store) {
    * @param {Object} state
    */
 		var update = function update(state) {
+			var propertiesChanged = false;
 			bindings.forEach(function (name) {
 				var _properties$name = properties[name],
 				    statePath = _properties$name.statePath,
@@ -90,9 +91,13 @@ function PolymerRedux(store) {
 				if (readOnly) {
 					element._setProperty(name, value);
 				} else {
-					element[name] = value;
+					element._setPendingPropertyOrPath(name, value);
+					propertiesChanged = true;
 				}
 			});
+			if (propertiesChanged) {
+				element._invalidateProperties();
+			}
 		};
 
 		// Redux listener

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ export default function PolymerRedux(store) {
 		 * @param {Object} state
 		 */
 		const update = state => {
+			let propertiesChanged = false;
 			bindings.forEach(name => {
 				const {statePath, readOnly} = properties[name];
 				const value = (typeof statePath === 'function') ?
@@ -64,9 +65,13 @@ export default function PolymerRedux(store) {
 				if (readOnly) {
 					element._setProperty(name, value);
 				} else {
-					element[name] = value;
+					element._setPendingPropertyOrPath(name, value);
+					propertiesChanged = true;
 				}
 			});
+			if (propertiesChanged) {
+				element._invalidateProperties();
+			}
 		};
 
 		// Redux listener

--- a/src/index.js
+++ b/src/index.js
@@ -56,18 +56,14 @@ export default function PolymerRedux(store) {
 		 */
 		const update = state => {
 			let propertiesChanged = false;
-			bindings.forEach(name => {
-				const {statePath, readOnly} = properties[name];
+			bindings.forEach(name => { // Perhaps .reduce() to a boolean?
+				const {statePath} = properties[name];
 				const value = (typeof statePath === 'function') ?
 					statePath.call(element, state) :
 					Polymer.Path.get(state, statePath);
 
-				if (readOnly) {
-					element._setProperty(name, value);
-				} else {
-					element._setPendingPropertyOrPath(name, value);
-					propertiesChanged = true;
-				}
+				const changed = element._setPendingPropertyOrPath(name, value, true);
+				propertiesChanged = propertiesChanged || changed;
 			});
 			if (propertiesChanged) {
 				element._invalidateProperties();


### PR DESCRIPTION
Steps to reproduce:

1. Having two properties in state mapped to two different polymer element properties.
2. Add multiple properties observer on those properties using "static get observers()" method.
3. Change both properties in state in one reducer.

Result: multiple observer's callback is called twice, with properties changing one by one. 
Expected: multiple observer's callback should be called only once with new values.