### PR TITLE
Fix typo in docs.md

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -31,7 +31,7 @@ const reducer = (state, action) => {
       return {
         ...state,
         array: [
-          ...array,
+          ...state.array,
           action.value
         ]
       }


### PR DESCRIPTION
Changing `array` to `state.array` since `array` was not defined in the scope of the reducer. An alternative would be to destructure `state`.